### PR TITLE
Fix issue with LAST query

### DIFF
--- a/Firmware/IotaWatt/influxDB.cpp
+++ b/Firmware/IotaWatt/influxDB.cpp
@@ -131,7 +131,7 @@ uint32_t influxService(struct serviceBlock* _serviceBlock){
       trace(T_influx,4);
       request->setReqHeader("Content-Type","application/x-www-form-urlencoded");
       reqData.flush();
-      reqData.printf_P(PSTR("db=%s&epoch=s&q=SELECT LAST(%s) FROM %s"), influxDataBase,
+      reqData.printf_P(PSTR("db=%s&rp=%s&epoch=s&q=SELECT LAST(%s) FROM %s"), influxDataBase, influxRetention,
             influxVarStr(influxFieldKey, script).c_str(),
             influxVarStr(influxMeasurement, script).c_str());
       influxTag* tag = influxTagSet;


### PR DESCRIPTION
Found this bug as my IoTaWatt resets on occasion and begins re-uploading all of the data to influxDB beginning at the "upload history from" date.  Wireshark collected the following after a reboot:

```
POST /query HTTP/1.1
host: **myInfluxDBserver**:8086
Authorization:Basic **myInfluxDBpassword**
Content-Type:application/x-www-form-urlencoded
Content-Length:63

db=iotawatt&epoch=s&q=SELECT LAST(value) FROM Clothes_Dryer_kwh
HTTP/1.1 200 OK
Content-Type: application/json
Request-Id: 19383a69-7c73-11ea-bca8-0242ac1e2101
X-Influxdb-Build: OSS
X-Influxdb-Version: 1.7.10
X-Request-Id: 19383a69-7c73-11ea-bca8-0242ac1e2101
Date: Sun, 12 Apr 2020 04:07:17 GMT
Transfer-Encoding: chunked

{"results":[{"statement_id":0}]}
```

I found that the reason for this is because IoTaWatt was not selecting my retention policy as it's a non-default policy on InfluxDB.

Queried with the retention policy:

```
POST /query HTTP/1.1
Host: **myInfluxDBserver**:8086
Authorization: Basic **myInfluxDBpassword**
User-Agent: curl/7.66.0
Accept: */*
Content-Length: 76
Content-Type: application/x-www-form-urlencoded

db=iotawatt&rp=One_Month&epoch=s&q=SELECT LAST(value) FROM Clothes_Dryer_kwh
HTTP/1.1 200 OK
Content-Type: application/json
Request-Id: 2cb2499d-7c7f-11ea-8429-0242ac1e2101
X-Influxdb-Build: OSS
X-Influxdb-Version: 1.7.10
X-Request-Id: 2cb2499d-7c7f-11ea-8429-0242ac1e2101
Date: Sun, 12 Apr 2020 05:33:44 GMT
Transfer-Encoding: chunked

{"results":[{"statement_id":0,"series":[{"name":"Clothes_Dryer_kwh","columns":["time","last"],"values":[[1586669620,3e-7]]}]}]}
```